### PR TITLE
Changes sbt deploy scripts to do cross version deployment.

### DIFF
--- a/sbt-deploy-ivy.sh
+++ b/sbt-deploy-ivy.sh
@@ -28,11 +28,11 @@ set -e
 
 if [[ $TRAVIS_PULL_REQUEST == "false" && $IS_RELEASE -eq 0 ]]; then
     if [ $# -eq 0 ]; then
-        sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci ';set publishTo in ThisBuild := Some("commbank-releases-ivy" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy"); set publishMavenStyle in ThisBuild  := false; publish'
+        sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci ';set publishTo in ThisBuild := Some("commbank-releases-ivy" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy"); set publishMavenStyle in ThisBuild  := false; + publish'
     else
         for project in $@; do
             echo "Publishing $project"
-            sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci ";project $project; set publishTo in ThisBuild := Some(\"commbank-releases-ivy\" at \"http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy\"); set publishMavenStyle in ThisBuild  := false; publish"
+            sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci ";project $project; set publishTo in ThisBuild := Some(\"commbank-releases-ivy\" at \"http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy\"); set publishMavenStyle in ThisBuild  := false; + publish"
         done
     fi
 else

--- a/sbt-deploy-to.sh
+++ b/sbt-deploy-to.sh
@@ -50,11 +50,11 @@ if [[ $TRAVIS_PULL_REQUEST == "false" && $IS_RELEASE -eq 0 ]]; then
         projects=${*:2}
         if [ $# -eq 1 ]; then
             echo "Publishing to repository $repository"
-            sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci "; $publishTo; $publishMavenStyle; publish"
+            sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci "; $publishTo; $publishMavenStyle; + publish"
         else
             for project in $projects; do
                 echo "Publishing $project to repository $repository"
-                sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci ";project $project; $publishTo; $publishMavenStyle; publish"
+                sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci ";project $project; $publishTo; $publishMavenStyle; + publish"
             done
         fi
     fi

--- a/sbt-deploy.sh
+++ b/sbt-deploy.sh
@@ -39,12 +39,12 @@ set -e
 if [[ $TRAVIS_PULL_REQUEST == "false" && $IS_RELEASE -eq 0 ]]; then
     if [ $# -eq 0 ]; then
         echo "DEPRECATION MIGRATION: this script can be replaced by: sbt-deploy-to.sh ext-releases-local"
-        sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci ';set publishTo in ThisBuild := Some("commbank-releases" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local"); set publishMavenStyle in ThisBuild  := true; publish'
+        sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci ';set publishTo in ThisBuild := Some("commbank-releases" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local"); set publishMavenStyle in ThisBuild  := true; + publish'
     else
         echo "DEPRECATION MIGRATION: this script can be replaced by: sbt-deploy-to.sh ext-releases-local" $@ 
         for project in $@; do
             echo "Publishing $project"
-            sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci ";project $project; set publishTo in ThisBuild := Some(\"commbank-releases\" at \"http://commbank.artifactoryonline.com/commbank/ext-releases-local\"); set publishMavenStyle in ThisBuild  := true; publish"
+            sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci ";project $project; set publishTo in ThisBuild := Some(\"commbank-releases\" at \"http://commbank.artifactoryonline.com/commbank/ext-releases-local\"); set publishMavenStyle in ThisBuild  := true; + publish"
         done
     fi
 else


### PR DESCRIPTION
Since sbt plugins are still build against Scala 2.10 as part of the Scala 2.11 upgrade we will need to do cross version deployment for some projects.

FYI @laurencer @lancelet @SamRoberts