### PR TITLE
RELEASE_BRANCHES env var controls publishing

### DIFF
--- a/sbt-deploy-to.sh
+++ b/sbt-deploy-to.sh
@@ -24,7 +24,9 @@
 #                      (eg. ext-releases-local or libs-releases-local)
 #   projectN - a project name for sbt to deploy. If this is omitted, the
 #              default (top-level) project is deployed.
-
+#
+#   Please see settings.sh for a description of how to set which branches
+#   are released (i.e. actually published to artifactory).
 set -e
 set -u
 set -v
@@ -60,4 +62,7 @@ if [[ $TRAVIS_PULL_REQUEST == "false" && $IS_RELEASE -eq 0 ]]; then
     fi
 else
     echo "Not a release branch. Nothing to deploy."
+    echo "To deploy this branch ($TRAVIS_BRANCH), add it to the RELEASE_BRANCHES environment variable:"
+    echo "  travis env set RELEASE_BRANCHES ($TRAVIS_BRANCH ${RELEASE_BRANCHES[@]})"
+    echo "(Or, alternatively, set it using the Travis web interface.)"
 fi

--- a/settings.sh
+++ b/settings.sh
@@ -15,11 +15,17 @@
 #!/bin/bash
 
 # Common CI settings
-# Branches for which we should do a release
-releaseBranches=("master" "CDH5" "CDH5V1" "CDH5_new_deps" "realtime_patch")
+
+# The environment variable RELEASE_BRANCHES controls which branches are released
+# (ie. published to Artifactory). This variable should be set (in Travis) to an
+# array of branch names; for example:
+#   RELEASE_BRANCHES=("CDH5" "realtime")
+# The "master" branch is included automatically. The variable can be set using
+# the Travis web interface or the CLI app:
+#   travis env set RELEASE_BRANCHES ("CDH5" "realtime")
 
 # Checks if an array contains the specified element
-# Usage: containsElement "CDH5" ${release_branches[@]}
+# Usage: containsElement "CDH5" ${RELEASE_BRANCHES[@]}
 containsElement () {
     local e
     for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
@@ -29,6 +35,6 @@ containsElement () {
 # Checks if the specified branch is a release branch
 # Usage: isReleaseBranch "CDH5"
 isReleaseBranch () {
-    containsElement $1 ${releaseBranches[@]}
+    masterAndReleaseBranches=("master" "${RELEASE_BRANCHES[@]}")
+    containsElement $1 ${masterAndReleaseBranches[@]}
 }
-


### PR DESCRIPTION
  - Use an external environment variable to control which branches
    of the project are published to artifactory
  - The master branch is included by default (so that existing projects
    without special branches can update without changes in Travis)