### PR TITLE
RELEASE_BRANCHES env var controls publishing (take 2)

### DIFF
--- a/sbt-deploy-to.sh
+++ b/sbt-deploy-to.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 #   Copyright 2014 Commonwealth Bank of Australia
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#!/bin/bash
-
 # sbt-deploy-to.sh targetRepository [ project1 project2 ... ]
 #
 #   Uses sbt to deploy artifacts to the chosen target repository. Optionally,
@@ -24,7 +24,9 @@
 #                      (eg. ext-releases-local or libs-releases-local)
 #   projectN - a project name for sbt to deploy. If this is omitted, the
 #              default (top-level) project is deployed.
-
+#
+#   Please see settings.sh for a description of how to set which branches
+#   are released (i.e. actually published to artifactory).
 set -e
 set -u
 set -v
@@ -59,5 +61,16 @@ if [[ $TRAVIS_PULL_REQUEST == "false" && $IS_RELEASE -eq 0 ]]; then
         fi
     fi
 else
+    # format the string describing the added branch nicely
+    read -a branchesArray <<< "${RELEASE_BRANCHES-}"
+    if [ ${#branchesArray[@]} -eq 0 ]; then
+        addedBranch="\"$TRAVIS_BRANCH\""
+    else
+        addedBranch="\"$TRAVIS_BRANCH ${branchesArray[@]-}\""
+    fi
+    # tell the user what to do if they want their branch deployed
     echo "Not a release branch. Nothing to deploy."
+    echo "To deploy this branch ($TRAVIS_BRANCH), add it to the RELEASE_BRANCHES environment variable:"
+    echo "  travis env set RELEASE_BRANCHES $addedBranch"
+    echo "(Or, alternatively, set it using the Travis web interface.)"
 fi

--- a/settings.sh
+++ b/settings.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #   Copyright 2014 Commonwealth Bank of Australia
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,14 +13,18 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#!/bin/bash
-
 # Common CI settings
-# Branches for which we should do a release
-releaseBranches=("master" "CDH5" "CDH5V1" "CDH5_new_deps" "realtime_patch")
+
+# The environment variable RELEASE_BRANCHES controls which branches are released
+# (ie. published to Artifactory). This variable should be set (in Travis) to a
+# space-separated string containing branch names; for example:
+#   RELEASE_BRANCHES="CDH5 realtime"
+# The "master" branch is included automatically. The variable can be set using
+# the Travis web interface or the CLI app:
+#   travis env set RELEASE_BRANCHES "CDH5 realtime"
 
 # Checks if an array contains the specified element
-# Usage: containsElement "CDH5" ${release_branches[@]}
+# Usage: containsElement "CDH5" ${branchArray[@]}
 containsElement () {
     local e
     for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
@@ -29,6 +34,7 @@ containsElement () {
 # Checks if the specified branch is a release branch
 # Usage: isReleaseBranch "CDH5"
 isReleaseBranch () {
-    containsElement $1 ${releaseBranches[@]}
+    read -a branchesArray <<< "${RELEASE_BRANCHES-}"
+    masterAndReleaseBranches=("master" "${branchesArray[@]-}")
+    containsElement $1 ${masterAndReleaseBranches[@]}
 }
-


### PR DESCRIPTION
  - Use an external environment variable to control which branches
    of the project are published to artifactory
  - The master branch is included by default (so that existing projects
    without special branches can update without changes in Travis)
  - Nice (properly formatted) log message to tell the user how to add their branch for publication