### PR TITLE
Use ssh to push github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ Travis Setup
    `travis enable --pro` or `travis enable --org`.
 5. Add the encrypted artifactory password. By running this command in the same directory as `.travis.yml`. `travis 
    encrypt ARTIFACTORY_PASSWORD=...`.
-6. [Optional to publish documentation] Create a branch called `gh-pages` for the project and push it to github. 
-   Then add the encrypted github password by running this command in the same directory as `.travis.yml`. 
-   `travis encrypt GH_PASSWORD=...`.
+6. [Optional to publish documentation] **For public repos only** Create a branch called `gh-pages` for the project and push it to github. Then add the private key for omnia-bamboo as an encrypted file.
+   1. Get the private key
+   1. Create a folder in the repo `.travis`
+   1. Run the command `travis encrypt-file <private-key> --add`
+   1. `travis encrypt-file <path-private-key> .travis/deploy-key.enc -w .travis/deploy-key --add`
+   1. For sbt builds add the `ci/sbt-gh-pages-ssh.sh` to the build commands.
 
 Publishing a Branch to Artifactory
 ----------------------------------
@@ -52,7 +55,7 @@ install:
 - ci/sbt-setup-version.sh
 script:
 - sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci ';  project all; test; package; project
-  example; assembly; project tools; assembly' && ci/sbt-deploy-to.sh ext-releases-local && ci/gh-pages.sh
+  example; assembly; project tools; assembly' && ci/sbt-deploy-to.sh ext-releases-local && ci/sbt-gh-pages-ssh.sh
 after_script:
 - rm -rf ci
 env:

--- a/gh-pages.sh
+++ b/gh-pages.sh
@@ -17,35 +17,5 @@
 set -e
 set -v
 
-
-version=$(grep "version" version.sbt | cut -d'=' -f 2)
-
-echo "" >> src/site/_config.yml
-echo "releaseVersion: $version" >> src/site/_config.yml
-
-echo "Creating site"
-sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci make-site
-
-# Only update gh-pages if we are on master.
-if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" ]]; then
-    set -u
-
-    git config --global user.email "omnia-bamboo"
-    git config --global user.name "Travis"
-
-    echo "Cloning gh-pages"
-    git clone -b gh-pages https://omnia-bamboo:$GH_PASSWORD@github.com/$TRAVIS_REPO_SLUG.git target/gh-pages
-
-    cd ./target/gh-pages
-    git rm -r -f --ignore-unmatch *
-    cp -r ../site/* .
-  
-    git add .
-    git commit -m "Updated site"
-    echo "Pushing site to gh-pages"
-    git push --quiet https://omnia-bamboo:$GH_PASSWORD@github.com/$TRAVIS_REPO_SLUG.git gh-pages
-    cd ..
-    rm -rf gh-pages
-else
-    echo "Not on master. Not updating docs."
-fi
+echo "This script is deprecated for security reasons please use ci/sbt-gh-pages-ssh.sh. See the ci/README for help" >&2
+exit 1

--- a/sbt-gh-pages-ssh.sh
+++ b/sbt-gh-pages-ssh.sh
@@ -1,0 +1,55 @@
+#   Copyright 2016 Commonwealth Bank of Australia
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+#!/bin/bash
+
+set -e
+set -v
+
+
+version=$(grep "version" version.sbt | cut -d'=' -f 2)
+
+echo "" >> src/site/_config.yml
+echo "releaseVersion: $version" >> src/site/_config.yml
+
+echo "Creating site"
+sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci make-site
+
+# Only update gh-pages if we are on master.
+if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" ]]; then
+    set -u
+
+    eval "$(ssh-agent -s)"
+    chmod 600 .travis/deploy-key.pem
+    ssh-add .travis/deploy-key.pem
+
+    git config --global user.email "omnia-bamboo"
+    git config --global user.name "Travis"
+
+    echo "Cloning gh-pages"
+    git clone -b gh-pages git@github.com:$TRAVIS_REPO_SLUG.git target/gh-pages
+
+    cd ./target/gh-pages
+    git rm -r -f --ignore-unmatch *
+    cp -r ../site/* .
+
+    git add .
+    git commit -m "Updated site"
+    echo "Pushing site to gh-pages"
+    git push --quiet git@github.com:$TRAVIS_REPO_SLUG.git gh-pages
+    cd ..
+    rm -rf gh-pages
+else
+    echo "Not on master. Not updating docs."
+fi


### PR DESCRIPTION
Uses a more secure approach with ssh keys to push to github pages.

Changes the existing gh-pages to return an error and point to `sbt-gh-pages-ssh.sh`.