### PR TITLE
Add bashcov and coveralls test coverage support.

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-ci
+

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,4 @@
+require 'coveralls'
+
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
+language: ruby
+rvm:
+- 2.2.0
+before_script:
+- gem install bashcov
+- gem install coveralls
 script:
-- ./test
+- bashcov -- ./test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ ci
 ==
 
 [![Build Status](https://travis-ci.org/CommBank/ci.svg?branch=master)](https://travis-ci.org/CommBank/ci)
+[![Coverage Status](https://coveralls.io/repos/github/wrouesnel/ci/badge.svg?branch=master)](https://coveralls.io/github/wrouesnel/ci?branch=master)
 
 Scripts used for Continuous Integration
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ ci
 ==
 
 [![Build Status](https://travis-ci.org/CommBank/ci.svg?branch=master)](https://travis-ci.org/CommBank/ci)
-[![Coverage Status](https://coveralls.io/repos/github/wrouesnel/ci/badge.svg?branch=master)](https://coveralls.io/github/wrouesnel/ci?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/CommBank/ci/badge.svg?branch=master)](https://coveralls.io/github/CommBank/ci?branch=master)
 
 Scripts used for Continuous Integration
 


### PR DESCRIPTION
Adds support for calculating and uploading test coverage support to coveralls.io.

Full support would require coveralls.io to be turned on for the CommBank/ci branch (example of output: https://coveralls.io/builds/5631204).

This is a working version of the series of unfortunately pushed changes previously :)