### PR TITLE
`atexit` function and test fix ups

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
 build:
-  image: ubuntu:wily
+  image: docker.artifactory.br.zbi.cba/zbi/build-scala:0.1.0-20160418075450-9b6bdd2
   commands:
   - ./test.bsh

--- a/lib-ci
+++ b/lib-ci
@@ -23,6 +23,31 @@ function echoerr() {
     echo "$@" 1>&2
 }
 
+# The following set of hooks allow you to inline defer function and method calls
+# in bash until the script terminates. It *requires* a line like 
+# `trap "atexit_commands" INT TERM EXIT` in the body of the bash script in order to 
+# work. Functions are a stack, and are executed in reverse order.
+# Typical usage:
+# trap "atexit_commands ; exit 0" INT TERM EXIT
+# atexit echo "This is run at exit"
+export atexit_hooks=()
+function atexit() {
+    val=$(echo "$@")
+    atexit_hooks+=("$val")
+}
+
+function atexit_commands() {
+    if [ -z "$TEST_DEBUG" ]; then
+        echoerr "Running shutdown hooks..."
+        for ((i=${#atexit_hooks[@]}-1; i >=0 ; i--)); do
+            echoerr "${atexit_hooks[$i]}"
+            eval "${atexit_hooks[$i]}"
+            # Blank elements don't eval to anything, so are removed.
+            atexit_hooks[$i]='' 
+        done
+    fi
+}
+
 # Parses a URL to extract the hostname
 function Hostname_From_Url() {
     # Do we have a scheme?

--- a/sbt-ci-build-doc.bsh
+++ b/sbt-ci-build-doc.bsh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 #   Copyright 2016 Commonwealth Bank of Australia
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,12 +67,23 @@ echo "" >> src/site/_config.yml
 sed -i '/^releaseVersion: .*/d' src/site/_config.yml 
 echo "releaseVersion: $version" >> src/site/_config.yml
 
+if [ -z $SBT ]; then
+    if [ -x "sbt" ]; then
+        SBT="sbt"
+    elif [ -x "./sbt" ]; then
+        SBT="./sbt"
+    else
+        echoerr "sbt is not specified by SBT env var, nor found. Aborting."
+        exit 1
+    fi
+fi
+
 # Builds documentation.
 function do_build_doc() {
     mkdir -p target/site
 
     echo "Creating documentation..."
-    sbt -Dsbt.global.base=$CI_BUILD_DIR \
+    $SBT -Dsbt.global.base=$CI_BUILD_DIR \
         "set uniform.docRootUrl := \"$docUrlRoot\"" \
         "set uniform.docSourceUrl := \"$docSourceUrlTemplate\"" \
         make-site

--- a/tests/test-lib-ci.bsh
+++ b/tests/test-lib-ci.bsh
@@ -77,3 +77,30 @@ export ENABLE_LOCAL_CI=
 WVPASS [ $(Hostname_From_Url "http://test/some/args?hello") = "test" ]
 WVPASS [ $(Hostname_From_Url "http://test.example.com/some/args?hello") = "test.example.com" ]
 WVPASS [ $(Hostname_From_Url "https://test2.ports.com:443/some/args?hello") = "test2.ports.com:443" ]
+
+# Test atexit
+cat << EOF > .test_lib_ci_atexit.bsh
+#!/bin/bash -x
+. ./lib-ci
+trap "atexit_commands; exit 0" INT TERM EXIT
+echo "In test script"
+atexit echo "Produced by atexit hook"
+atexit touch .made_by_atexit
+EOF
+chmod +x .test_lib_ci_atexit.bsh
+WVPASS ./.test_lib_ci_atexit.bsh
+WVPASS [ -e .made_by_atexit ]
+rm .made_by_atexit
+rm .test_lib_ci_atexit.bsh
+
+# Check the atexit commands don't propagate
+cat << EOF > .test_lib_ci_atexit_fail.bsh
+#!/bin/bash -x
+. ./lib-ci
+trap "atexit_commands; exit 0" INT TERM EXIT
+EOF
+chmod +x .test_lib_ci_atexit_fail.bsh
+WVPASS ./.test_lib_ci_atexit_fail.bsh
+WVPASS [ ! -e .made_by_atexit ]
+rm .test_lib_ci_atexit_fail.bsh
+

--- a/tests/test-sbt-ci-build-doc.bsh
+++ b/tests/test-sbt-ci-build-doc.bsh
@@ -17,6 +17,7 @@ SCRIPT_DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$SCRIPT_DIR" ]]; then SCRIPT_DIR="$PWD"; fi
 
 # Testing the test fixtures
+ORIG_PWD=$(pwd)
 cd $SCRIPT_DIR/test-sbt-ci-build-doc
 
 ORIG_CI_BRANCH=$CI_BRANCH
@@ -24,7 +25,7 @@ ORIG_CI_BRANCH=$CI_BRANCH
 # We need to do some setup - namely, turning the test fixture root into a
 # git repository. sbt-ci-build-doc will then operate on this repo in a
 # subdirectory.
-git init || exit 1
+git init . || exit 1
 git config user.email "zbi+test@cba.com.au"
 git config user.name "WVTEST"
 git add -A || exit 1
@@ -32,7 +33,7 @@ git commit -m "Initial commit" || exit 1
 git symbolic-ref HEAD refs/heads/master || exit 1
 
 # Test that we fail when there is no git remote.
-export CI_BRANCH=master
+export FORCE_PUBLISH=yes
 WVFAIL ../../sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
 
 # Make a git remote to allow the script to find one
@@ -41,24 +42,7 @@ git remote add origin $(readlink -f $TMPREMOTE) || exit 1
 # This should now run correctly.
 WVPASS ../../sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
 
-ls -l
-
-#WVPASS [ -d "target/site" ]
-# Delete that directory
-#rm -rf "target/site"
-
-# Confirm we do nothing successfully when not master
-export CI_BRANCH=notmaster
-WVPASS ../../sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
-#WVPASS [ ! -d "target/site" ]
-
-# Confirm FORCE_DOCS works
-export CI_BRANCH=notmaster
-WVPASS ../../sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
-
-export CI_BRANCH=$ORIG_CI_BRANCH
-
 # Remove temporary directories
 rm -rf .gitkeep .git $TMPBASE $TMPREMOTE
 
-cd ../..
+cd $ORIG_PWD


### PR DESCRIPTION
Adds the `atexit` lib-ci command which is a convenient way to run deferred functions in bash. This is used along with some other miscellaneous changes to fix up how the tests run for the sbt-build-docs CI script (which involved removing some tests which are branch dependent and cannot run reliably without awkward debug tooling).